### PR TITLE
Hans on/open redirect

### DIFF
--- a/public/open_redirect.html
+++ b/public/open_redirect.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>オープンリダイレクト検証</title>
+  </head>
+  <body>
+    <h1>オープンリダイレクト検証</h1>
+    <div>ここはリダイレクト先です。</div>
+  </body>
+</html>

--- a/routes/api.js
+++ b/routes/api.js
@@ -30,4 +30,15 @@ router.get("/attack", (req, res, next) => {
   res.send("<script>alert('attack');</script>");
 });
 
+router.get("/redirect_constraint", (req, res) => {
+  const ALLOWED_REDIRECT = ["/open_redirect.html"];
+  if (!ALLOWED_REDIRECT.includes(req.query.url)) {
+    return res.status(400).send("Unauthorized redirect");
+  }
+  res.redirect(req.query.url);
+});
+
+router.get("/redirect_no_constraint", (req, res) => {
+  res.redirect(req.query.url);
+});
 module.exports = router;


### PR DESCRIPTION
- オープンリダイレクトのハンズオン
  - リダイレクト処理を実行する際、クエリ文字にパスに含まれていて、リダイレクト処理に制約を設けていない場合、悪意のあるページ飛ばされる危険性がある。

- 動作確認
  - 制約なし：制約がないため、クエリパラメータにセットしたパスにリダイレクトされる
      - 実行リンク：http://localhost:3000/redirect_no_constraint?url=/csrf_login.html

  - 制約あり：特定のリダイレクト先のみ実行可能としているため、クエリパラメータにセットされてもパスされない
      - 実行リンク: http://localhost:3000/api/redirect_constraint?url=/open_redirect.html


※基本的にはAPIでリダイレクト処理を実装しているときは、制約をかけてリダイレクト処理を実装する